### PR TITLE
Pkg 4812 12.4 initial

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,8 @@
 arm_variant_type:  # [aarch64]
   - sbsa           # [aarch64]
+c_stdlib:
+- sysroot          # [linux]
+- vs2017           # [win]
+c_stdlib_version:
+- '2.17'           # [linux and x86_64]
+- '2.26'           # [linux and aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - {{ stdlib("c") }}
         - patchelf <0.18.0                      # [linux]
       host:
@@ -87,7 +87,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - {{ stdlib("c") }}
       host:
         - cuda-version {{ cuda_version }}
@@ -124,7 +124,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - {{ stdlib("c") }}
       host:
         - cuda-version {{ cuda_version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
 build:
   number: 2
   binary_relocation: false
-  skip: true  # [osx]
+  skip: true  # [osx or (linux and s390x)]
 
 test:
   requires:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4812](https://anaconda.atlassian.net/browse/PKG-4812)

### Explanation of changes:

- Part of CUDA 12.4 build, following [conda-forge's pattern](https://github.com/conda-forge/staged-recipes/issues/21382) which was developed in conjunction with Nvidia. I don't see a need to stage these then release them all at once. They won't cause a problem released one at a time.
- Please check the main branch too, this has just been forked
- Changes made to adjust feedstocks for differences between conda-forge and defaults. Please see commit messages for description of changes.



[PKG-4812]: https://anaconda.atlassian.net/browse/PKG-4812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ