### PR TITLE
libnvfatbin v12.9.82

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+~/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
 arm_variant_type:  # [aarch64]
   - sbsa           # [aarch64]
-  - tegra          # [aarch64]
+#  - tegra          # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,12 +2,10 @@
 {% set version = "12.9.82" %}
 {% set cuda_version = "12.9" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
-{% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64 and arm_variant_type=="sbsa"]
 {% set platform = "linux-aarch64" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set platform = "windows-x86_64" %}  # [win]
 {% set target_name = "x86_64-linux" %}  # [linux64]
-{% set target_name = "ppc64le-linux" %}  # [ppc64le]
 {% set target_name = "sbsa-linux" %}  # [aarch64 and arm_variant_type=="sbsa"]
 {% set target_name = "aarch64-linux" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set target_name = "x64" %}  # [win]
@@ -26,8 +24,8 @@ source:
   sha256: 86563b25096bbc21d74b1c043701ec8596499f76b40e32f9ec9179fc10404d00  # [win]
 
 build:
-  number: 1
-  skip: true  # [osx or ppc64le]
+  number: 0
+  skip: true  # [osx]
 
 requirements:
   build:
@@ -38,6 +36,9 @@ outputs:
   - name: libnvfatbin
     build:
       binary_relocation: false
+      overlinking_ignore_patterns:
+        # Workaround for LIEF's 'not a valid TAG' error
+        - '*libnvfatbin*.so*'  # [linux and aarch64]
     files:
       - lib/libnvfatbin.so.*                             # [linux]
       - targets/{{ target_name }}/lib/libnvfatbin*.so.*  # [linux]
@@ -70,10 +71,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: NVIDIA compiler library for fatbin interaction
       description: |
         NVIDIA compiler library for fatbin interaction
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: libnvfatbin-dev
     build:
@@ -115,10 +118,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: NVIDIA compiler library for fatbin interaction
       description: |
         NVIDIA compiler library for fatbin interaction
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: libnvfatbin-static
     files:
@@ -144,20 +149,24 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: NVIDIA compiler library for fatbin interaction
       description: |
         NVIDIA compiler library for fatbin interaction
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
 about:
   home: https://developer.nvidia.com/cuda-toolkit
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: NVIDIA compiler library for fatbin interaction
   description: |
     NVIDIA compiler library for fatbin interaction
   doc_url: https://docs.nvidia.com/cuda/index.html
+  dev_url: https://docs.nvidia.com/cuda/index.html
 
 extra:
   feedstock-name: libnvfatbin


### PR DESCRIPTION
libnvfatbin 12.9.82

**Destination channel:** defaults

### Links

- [PKG-12785](https://anaconda.atlassian.net/browse/PKG-12785) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Based on upstream feedstock's `12.x` branch.
- Added `abs.yaml` for possible use of staging channels in future builds
- Removed Tegra builds from `cbc.yaml`. We may enable them in the future.
- Kept static library packages as they are dependencies for `cuda-libraries-static` package.


[PKG-12785]: https://anaconda.atlassian.net/browse/PKG-12785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ